### PR TITLE
build: Ignore target directory in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Log file
 *.log
 
+# target dir
+target
+
 # BlueJ files
 *.ctxt
 


### PR DESCRIPTION
Added 'target' directory to .gitignore to prevent it from being tracked in
version control.